### PR TITLE
Remove usage of migrateWarn function

### DIFF
--- a/src/jquery.live-polyfill.js
+++ b/src/jquery.live-polyfill.js
@@ -23,7 +23,7 @@
 
     if (typeof selector === 'string' && selector === '#') {
       // JQuery( "#" ) is a bogus ID selector, but it returned an empty set before jQuery 3.0
-      migrateWarn('jQuery(\'#\') is not a valid selector');
+      console.warn('jQuery(\'#\') is not a valid selector');
       args[0] = [];
     }
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | migrateWarn is not available in this scope, it can't be used here
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20950
| How to test?  | will be tested once prestashop 1.7.7 integrates this version of jquery.live-polyfill

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
